### PR TITLE
National post parser

### DIFF
--- a/newspaper/article.py
+++ b/newspaper/article.py
@@ -272,6 +272,16 @@ class Article(object):
 
         self.top_node = self.extractor.calculate_best_node(self.doc)
         if self.top_node is not None:
+            if self.top_node.tag == 'section':
+                if self.top_node.getparent().tag == 'div':
+                    similar_nodes = self.extractor.parser.getElementsByTag(self.doc,
+                                                                           self.top_node.tag,
+                                                                           attr='class',
+                                                                           value=self.top_node.get('class'))
+                    similar_nodes = [s for s in similar_nodes if s != self.top_node]
+                    for node in similar_nodes:
+                        self.top_node.insert(-1, node)
+
             video_extractor = VideoExtractor(self.config, self.top_node)
             self.set_movies(video_extractor.get_videos())
 

--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -27,11 +27,12 @@ class DocumentCleaner(object):
             "|communitypromo|runaroundLeft|subscribe|vcard|articleheadings"
             "|date|^print$|popup|author-dropdown|tools|socialtools|byline"
             "|konafilter|KonaFilter|breadcrumbs|^fn$|wp-caption-text"
-            "|legende|ajoutVideo|timestamp|js_replies"
+            "|legende|ajoutVideo|timestamp|js_replies|articleImage"
         )
 
         self.remove_nodes_class_re = (
-            "visually-hidden|video-fallback"
+            "visually-hidden|video-fallback|newsletter-widget|ad__placeholder|"
+            "polopoly_embed|ad__label|widget-title|sr-only"
         )
 
         self.regexp_namespace = "http://exslt.org/regular-expressions"

--- a/newspaper/cleaners.py
+++ b/newspaper/cleaners.py
@@ -32,7 +32,8 @@ class DocumentCleaner(object):
 
         self.remove_nodes_class_re = (
             "visually-hidden|video-fallback|newsletter-widget|ad__placeholder|"
-            "polopoly_embed|ad__label|widget-title|sr-only"
+            "polopoly_embed|ad__label|widget-title|sr-only|"
+            "share-button__wrapper|breadcrumbs|^more-topic$"
         )
 
         self.regexp_namespace = "http://exslt.org/regular-expressions"
@@ -54,6 +55,9 @@ class DocumentCleaner(object):
             .append("\t")\
             .append("^\\s+$")
         self.contains_article = './/article|.//*[@id="article"]|.//*[@itemprop="articleBody"]'
+        self.image_credit_re = '^credit|[^r][-_]credit|^distributor'
+        self.article_metadata_re = '^article-meta'
+        self.video_fallback_re = '^embed-height|^direct-embed-video|player-wrapper'
 
     def clean(self, doc_to_clean):
         """Remove chunks of the DOM as specified
@@ -71,6 +75,9 @@ class DocumentCleaner(object):
         doc_to_clean = self.remove_nodes_regex(doc_to_clean,
                                                self.facebook_broadcasting_re)
         doc_to_clean = self.remove_nodes_regex(doc_to_clean, self.twitter_re)
+        doc_to_clean = self.remove_nodes_regex(doc_to_clean, self.image_credit_re)
+        doc_to_clean = self.remove_nodes_regex(doc_to_clean, self.article_metadata_re)
+        doc_to_clean = self.remove_nodes_regex(doc_to_clean, self.video_fallback_re)
         doc_to_clean = self.clean_para_spans(doc_to_clean)
         doc_to_clean = self.div_to_para(doc_to_clean, 'div')
         doc_to_clean = self.div_to_para(doc_to_clean, 'span')

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -920,12 +920,21 @@ class ContentExtractor(object):
 
     def add_siblings(self, top_node):
         baseline_score_siblings_para = self.get_siblings_score(top_node)
-        results = self.walk_siblings(top_node)
-        for current_node in results:
+        # Adds previous siblings
+        previous_sibs = self.walk_siblings(top_node)
+        for current_node in previous_sibs:
             ps = self.get_siblings_content(
                 current_node, baseline_score_siblings_para)
             for p in ps:
                 top_node.insert(0, p)
+
+        # Add following siblings
+        following_sibs = [n for n in top_node.itersiblings()]
+        for current_node in following_sibs:
+            ps = self.get_siblings_content(current_node, baseline_score_siblings_para)
+            for p in ps:
+                top_node.append(p)
+
         return top_node
 
     def get_siblings_content(

--- a/newspaper/outputformatters.py
+++ b/newspaper/outputformatters.py
@@ -145,7 +145,7 @@ class OutputFormatter(object):
         last top level node's class is one of NON_MEDIA_CLASSES.
         """
 
-        NON_MEDIA_CLASSES = ('zn-body__read-all', )
+        NON_MEDIA_CLASSES = ('zn-body__read-all', 'content-list-component text')
 
         def get_depth(node, depth=1):
             """Computes depth of an lxml element via BFS, this would be


### PR DESCRIPTION
Parser updates to address content issues with National Post. In particular, this addresses the previous tendency for National Post articles to be cutoff after advertisements. 

This also introduces additional cleaning functions to the parser to take care of text associated with advertisements, metadata, and videos. 