### PR TITLE
Add feeds_only flag to skip category crawling

### DIFF
--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -86,6 +86,7 @@ class Configuration(object):
         self.document_cleaner = DocumentCleaner
 
         self.request_callback = None
+        self.feeds_only = False
 
     def get_language(self):
         return self._language

--- a/newspaper/source.py
+++ b/newspaper/source.py
@@ -91,9 +91,10 @@ class Source(object):
         self.download()
         self.parse()
 
-        self.set_categories()
-        self.download_categories()  # mthread
-        self.parse_categories()
+        if not self.config.feeds_only:
+            self.set_categories()
+            self.download_categories()  # mthread
+            self.parse_categories()
 
         self.set_feeds()
         self.download_feeds()  # mthread


### PR DESCRIPTION
When feeds_only=True, Source.build() skips set_categories(), download_categories(), and parse_categories(), going straight to feed discovery. Eliminates category page HTTP hits for outlets that use RSS exclusively.