### PR TITLE
Add LeDevoirContentExtractor that skips feed URL purge

### DIFF
--- a/newspaper/configuration.py
+++ b/newspaper/configuration.py
@@ -87,6 +87,7 @@ class Configuration(object):
 
         self.request_callback = None
         self.feeds_only = False
+        self.skip_feed_url_purge = False
 
     def get_language(self):
         return self._language

--- a/newspaper/extractors.py
+++ b/newspaper/extractors.py
@@ -1479,3 +1479,18 @@ class CTVNewsContentExtractor(ContentExtractor):
             return date_parser(dt_str)
         except Exception:
             return None
+
+
+class LeDevoirContentExtractor(ContentExtractor):
+    """Le Devoir serves all articles via RSS feeds (feeds_only=True).
+    URLs in RSS <link> tags are editorially curated article links — they
+    don't need the generic valid_url() heuristics, which were designed for
+    filtering URLs scraped from HTML category pages and reject many
+    legitimate Le Devoir URLs (short slugs, no date in path).
+    Setting skip_feed_url_purge signals feeds_to_articles() to trust
+    the feed URLs directly.
+    """
+
+    def __init__(self, config):
+        super().__init__(config)
+        self.config.skip_feed_url_purge = True

--- a/newspaper/source.py
+++ b/newspaper/source.py
@@ -271,7 +271,8 @@ class Source(object):
                     config=self.config)
                 cur_articles.append(article)
 
-            cur_articles = self.purge_articles('url', cur_articles)
+            if not self.config.skip_feed_url_purge:
+                cur_articles = self.purge_articles('url', cur_articles)
             after_purge = len(cur_articles)
 
             if self.config.memoize_articles:


### PR DESCRIPTION
RSS <link> tags are editorially curated article URLs and don't need the generic valid_url() heuristics, which reject many legitimate Le Devoir URLs (short slugs, no 19xx/20xx date in path). A new skip_feed_url_purge flag on Configuration causes feeds_to_articles() to bypass purge_articles('url', ...) when set.

LeDevoirContentExtractor sets this flag in __init__, following the existing pattern of outlet-specific ContentExtractor subclasses.